### PR TITLE
Fix MAX_FILE_SIZE_MB.

### DIFF
--- a/App.py
+++ b/App.py
@@ -6,7 +6,7 @@ from FileManager import FileManager
 from Cryptography import Cryptography
 
 # Size is 2048 MB, but encryption increases the file size by about 30%
-MAX_FILE_SIZE_MB = 1600
+MAX_FILE_SIZE_MB = 1500
 MB_TO_BYTES = 1024 * 1024
 
 


### PR DESCRIPTION
Decrease variable value of MAX_FILE_SIZE_MB from 1600 to 1500 because after 30% increase due to encryption , the file size will exceed 2048MB limit.